### PR TITLE
Unify F1000Research naming convention

### DIFF
--- a/data_journals_characteristics.csv
+++ b/data_journals_characteristics.csv
@@ -85,7 +85,7 @@ ISSN,journal_title,publisher,URL,data_journal_type
 2639-5916,Ecosystems and People,Taylor & Francis,https://www.tandfonline.com/journals/tbsm22,mixed
 2050-084X,eLife,eLife Sciences Publications,https://elifesciences.org/,mixed
 2041-9139,EvoDevo,BioMed Central (Springer Nature),https://evodevojournal.biomedcentral.com/,mixed
-2046-1402,F1000Research,F1000 Research,https://f1000research.com/,mixed
+2046-1402,F1000Research,F1000Research,https://f1000research.com/,mixed
 2197-5620,Forest Ecosystems,Elsevier,https://www.sciencedirect.com/journal/forest-ecosystems,mixed
 2312-6604,Freshwater Metadata Journal,University of Natural Resources and Life Sciences Vienna,http://data.freshwaterbiodiversity.eu/fmj/,pure
 1756-994X,Genome Medicine,BioMed Central (Springer Nature),https://genomemedicine.biomedcentral.com/,mixed
@@ -141,5 +141,5 @@ ISSN,journal_title,publisher,URL,data_journal_type
 1365-313X,The Plant Journal,Blackwell Publishing (Wiley),https://onlinelibrary.wiley.com/journal/1365313x,mixed
 2578-2703,The Plant Phenome Journal,John Wiley & Sons (Wiley),https://acsess.onlinelibrary.wiley.com/journal/25782703,mixed
 2603-431X,Viticulture Data Journal,Pensoft Publishers,https://vdj.pensoft.net/,pure
-2398-502X,Wellcome Open Research,F1000 Research,https://wellcomeopenresearch.org/,mixed
+2398-502X,Wellcome Open Research,F1000Research,https://wellcomeopenresearch.org/,mixed
 


### PR DESCRIPTION
Hi,

Thank you for compiling this very helpful list! I have unified two different spellings (`F1000 Research` and `F1000Research`) to "F1000Research" to align the naming convention to official sources (example: https://www.f1000.com/resources-for-researchers/where-to-publish-your-research/f1000research/) and would be happy if you'd accept my PR.

Best,
Thomas