### PR TITLE
Various fixes

### DIFF
--- a/data_journals_characteristics.csv
+++ b/data_journals_characteristics.csv
@@ -1,6 +1,6 @@
 ISSN,journal_title,publisher,URL,data_journal_type
 2574-5417,Big Earth Data,Taylor & Francis,https://www.tandfonline.com/journals/tbed20,mixed
-1809-127X,Pensoft,Check List,https://checklist.pensoft.net/,pure
+1809-127X,Check List,Pensoft,https://checklist.pensoft.net/,pure
 1698-0476,Museu de Ciéncies Naturals de Barcelona,Arxius de Miscel·lània Zoològica,https://museucienciesjournals.cat/en/amz,pure
 1941-4927,NCHS Data Briefs,Centers for Disease Control and Preventions (CDC),https://www.cdc.gov/nchs/products/databriefs.htm,pure
 1758-0463,Database: The Journal of Biological Databases and Curation,Oxford University Press,https://academic.oup.com/database,pure

--- a/data_journals_characteristics.csv
+++ b/data_journals_characteristics.csv
@@ -25,7 +25,7 @@ ISSN,journal_title,publisher,URL,data_journal_type
 1471-2261,BMC Cardiovascular Disorders,BioMed Central (Springer Nature),https://bmccardiovascdisord.biomedcentral.com/,mixed
 2661-801X,BMC Chemistry,BioMed Central (Springer Nature),https://bmcchem.biomedcentral.com/,mixed
 1472-6882,BMC Complementary and Alternative Medicine,BioMed Central (Springer Nature),https://bmccomplementmedtherapies.biomedcentral.com/,mixed
-1472-6785,BMC Ecology,BioMed Central (Springer Nature),https://bmcbiotechnol.biomedcentral.com/,mixed
+1472-6785,BMC Ecology,BioMed Central (Springer Nature),https://bmcecol.biomedcentral.com/,mixed
 1471-227X,BMC Emergency Medicine,BioMed Central (Springer Nature),https://bmcemergmed.biomedcentral.com/,mixed
 1472-6823,BMC Endocrine Disorders,BioMed Central (Springer Nature),https://bmcendocrdisord.biomedcentral.com/,mixed
 1471-2148,BMC Evolutionary Biology,BioMed Central (Springer Nature),https://bmcecolevol.biomedcentral.com/,mixed

--- a/data_journals_characteristics.csv
+++ b/data_journals_characteristics.csv
@@ -85,7 +85,7 @@ ISSN,journal_title,publisher,URL,data_journal_type
 2639-5916,Ecosystems and People,Taylor & Francis,https://www.tandfonline.com/journals/tbsm22,mixed
 2050-084X,eLife,eLife Sciences Publications,https://elifesciences.org/,mixed
 2041-9139,EvoDevo,BioMed Central (Springer Nature),https://evodevojournal.biomedcentral.com/,mixed
-2046-1402,F1000Research,F1000 Research,https://f1000research.com/,mixed
+2046-1402,F1000Research,F1000Research,https://f1000research.com/,mixed
 2197-5620,Forest Ecosystems,Elsevier,https://www.sciencedirect.com/journal/forest-ecosystems,mixed
 2312-6604,Freshwater Metadata Journal,University of Natural Resources and Life Sciences Vienna,http://data.freshwaterbiodiversity.eu/fmj/,pure
 1756-994X,Genome Medicine,BioMed Central (Springer Nature),https://genomemedicine.biomedcentral.com/,mixed
@@ -141,5 +141,5 @@ ISSN,journal_title,publisher,URL,data_journal_type
 1365-313X,The Plant Journal,Blackwell Publishing (Wiley),https://onlinelibrary.wiley.com/journal/1365313x,mixed
 2578-2703,The Plant Phenome Journal,John Wiley & Sons (Wiley),https://acsess.onlinelibrary.wiley.com/journal/25782703,mixed
 2603-431X,Viticulture Data Journal,Pensoft Publishers,https://vdj.pensoft.net/,pure
-2398-502X,Wellcome Open Research,F1000 Research,https://wellcomeopenresearch.org/,mixed
+2398-502X,Wellcome Open Research,F1000Research,https://wellcomeopenresearch.org/,mixed
 

--- a/data_journals_characteristics.csv
+++ b/data_journals_characteristics.csv
@@ -78,7 +78,6 @@ ISSN,journal_title,publisher,URL,data_journal_type
 2306-5729,Data,MDPI,https://www.mdpi.com/journal/data,mixed
 2352-3409,Data in Brief,Elsevier,https://www.sciencedirect.com/journal/data-in-brief,pure
 1683-1470,Data Science Journal,Ubiquity Press,https://datascience.codata.org/,mixed
-1758-0463,Database,Oxford University Press,https://academic.oup.com/database,mixed
 1866-3516,Earth System Science Data,Copernicus,https://www.earth-system-science-data.net/,pure
 1440-1703,Ecological Research,Blackwell Publishing (Wiley),https://esj-journals.onlinelibrary.wiley.com/journal/14401703,mixed
 1939-9170,Ecology,John Wiley & Sons (Wiley),https://esajournals.onlinelibrary.wiley.com/journal/19399170,mixed

--- a/data_journals_characteristics.csv
+++ b/data_journals_characteristics.csv
@@ -1,7 +1,7 @@
 ISSN,journal_title,publisher,URL,data_journal_type
 2574-5417,Big Earth Data,Taylor & Francis,https://www.tandfonline.com/journals/tbed20,mixed
 1809-127X,Check List,Pensoft,https://checklist.pensoft.net/,pure
-1698-0476,Museu de Ciéncies Naturals de Barcelona,Arxius de Miscel·lània Zoològica,https://museucienciesjournals.cat/en/amz,pure
+1698-0476,Arxius de Miscel·lània Zoològica,Museu de Ciències Naturals de Barcelona,https://museucienciesjournals.cat/en/amz,pure
 1941-4927,NCHS Data Briefs,Centers for Disease Control and Preventions (CDC),https://www.cdc.gov/nchs/products/databriefs.htm,pure
 1758-0463,Database: The Journal of Biological Databases and Curation,Oxford University Press,https://academic.oup.com/database,pure
 2709-4715,Gigabyte,BGI and Oxford University Press,https://gigabytejournal.com/,pure


### PR DESCRIPTION
This PR includes various fixes for `data_journals_characteristics.csv`:

- Unified two different spellings (F1000 Research and F1000Research) to "F1000Research" to align the naming convention to official sources (example: https://www.f1000.com/resources-for-researchers/where-to-publish-your-research/f1000research/) (495a2963f8aa14e6dfbc60c01ad1f8e3e528fa66)
- Fixed "Check List" journal entry: The name of the journal and name of the publisher were switched (b6fa2bc785efb88e19a6f59c3747b324a06063d2)
- Fixed "Arxius de Miscel·lània Zoològica" journal entry: The journal name and the publisher were switched; fixed the accent in the publisher too (579edd3023e5c36d4e0d2bc4cde2b414c707fb22)
- Fixed a wrong URL for the "BMC Ecology" journal (8e4692fae4991730bf55f9e926d67ca8226a9425)
- Removed a duplicate entry for ISSN 1758-0463 (779331eaff02e85d54483773eccc4fae72e1c630): the removed entry had an incomplete title ("Database" instead of "Database: The Journal of Biological Databases and Curation"); the journal_type was "mixed" instead of "pure". As stated on the journal's website "pure" would be a better classification: https://academic.oup.com/database/pages/About